### PR TITLE
All bri / sat vules from 0-255

### DIFF
--- a/PoSHue.ps1
+++ b/PoSHue.ps1
@@ -391,9 +391,9 @@ Class HueLight : HueFactory {
     [ValidateLength(5, 50)][string] $APIKey
     [ValidateLength(1, 2000)][string] $JSON
     [bool] $On
-    [ValidateRange(1, 254)][int] $Brightness
+    [ValidateRange(0, 255)][int] $Brightness
     [ValidateRange(0, 65535)][int] $Hue
-    [ValidateRange(0, 254)][int] $Saturation
+    [ValidateRange(0, 255)][int] $Saturation
     [ValidateRange(153, 500)][int] $ColourTemperature
     [hashtable] $XY = @{ x = $null; y = $null }    
     [bool] $Reachable
@@ -1122,9 +1122,9 @@ Class HueGroup : HueFactory {
     [ValidateLength(5, 50)][string] $APIKey
     [ValidateLength(1, 2000)][string] $JSON
     [bool] $On
-    [ValidateRange(1, 254)][int] $Brightness
+    [ValidateRange(0, 255)][int] $Brightness
     [ValidateRange(0, 65535)][int] $Hue
-    [ValidateRange(0, 254)][int] $Saturation
+    [ValidateRange(0, 255)][int] $Saturation
     [ValidateRange(153, 500)][int] $ColourTemperature
     [hashtable] $XY = @{ x = $null; y = $null }
     [ColourMode] $ColourMode


### PR DESCRIPTION
Genuine Hue bulbs will return 1-254 for bri but other bulbs may do 0-255.

Sat may go to 255 according to Hue Core Concepts guide. https://www.developers.meethue.com/documentation/core-concepts